### PR TITLE
Feature/instrument realtime stats to wf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 .csv
 .DS_Store
 .accept-weathervane
+.idea
 
 # Created by https://www.gitignore.io/api/java,perl,gradle,eclipse,emacs
 

--- a/build.gradle
+++ b/build.gradle
@@ -309,7 +309,8 @@ project(':workloadDriver') {
 		logbackVersion = "1.1.3"	
 	}
 	
-	dependencies { 
+	dependencies {
+		runtimeOnly 'io.micrometer:micrometer-registry-wavefront:1.4.1'
 
 		compile "io.netty:netty-all:$nettyVersion"
 		compile "io.netty:netty-tcnative:2.0.25.Final:linux-x86_64-fedora"

--- a/build.gradle
+++ b/build.gradle
@@ -310,7 +310,12 @@ project(':workloadDriver') {
 	}
 	
 	dependencies {
-		runtimeOnly 'io.micrometer:micrometer-registry-wavefront:1.4.1'
+		compile 'io.micrometer:micrometer-registry-wavefront:latest.release'
+		compile 'io.micrometer:micrometer-spring-legacy:latest.release'
+
+//		Might be beneficial if we can just do prometheus and all users can
+//		configure prometheus to pull metrics from /prometheus
+//		compile 'io.micrometer:micrometer-registry-prometheus:latest.release'
 
 		compile "io.netty:netty-all:$nettyVersion"
 		compile "io.netty:netty-tcnative:2.0.25.Final:linux-x86_64-fedora"

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/metrics/WavefrontMicrometerConfig.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/metrics/WavefrontMicrometerConfig.java
@@ -1,0 +1,18 @@
+package com.vmware.weathervane.workloadDriver.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WavefrontMicrometerConfig {
+
+    @Bean
+    MeterRegistryCustomizer meterRegistryCustomizer(MeterRegistry meterRegistry) {
+        return mr -> {
+            meterRegistry.config()
+                    .commonTags("application", "wv-workload-runner");
+        };
+    }
+}

--- a/workloadDriver/src/main/resources/application.properties
+++ b/workloadDriver/src/main/resources/application.properties
@@ -3,11 +3,7 @@ server.port=${port:7500}
 endpoints.sensitive=false
 
 # Wavefront Publishing Config
-management.metrics.export.wavefront.batch-size=10000
-management.metrics.export.wavefront.connect-timeout=1s
 management.metrics.export.wavefront.enabled=true
-management.metrics.export.wavefront.global-prefix=wv_wld_driver
-management.metrics.export.wavefront.num-threads=2
-management.metrics.export.wavefront.read-timeout=10s
-management.metrics.export.wavefront.step=10s
-management.metrics.export.wavefront.uri=proxy://envoy-loadbalancer-ara-wf-proxy-cloud.ara.decc.vmware.com:80
+management.metrics.export.wavefront.source=wv-${HOSTNAME}
+management.metrics.export.wavefront.uri=proxy://${WF_PROXY:localhost}:${WV_PROXY_PORT:2878}
+management.metrics.export.wavefront.step=30s

--- a/workloadDriver/src/main/resources/application.properties
+++ b/workloadDriver/src/main/resources/application.properties
@@ -1,3 +1,13 @@
 server.port=${port:7500}
 
 endpoints.sensitive=false
+
+# Wavefront Publishing Config
+management.metrics.export.wavefront.batch-size=10000
+management.metrics.export.wavefront.connect-timeout=1s
+management.metrics.export.wavefront.enabled=true
+management.metrics.export.wavefront.global-prefix=wv_wld_driver
+management.metrics.export.wavefront.num-threads=2
+management.metrics.export.wavefront.read-timeout=10s
+management.metrics.export.wavefront.step=10s
+management.metrics.export.wavefront.uri=proxy://envoy-loadbalancer-ara-wf-proxy-cloud.ara.decc.vmware.com:80


### PR DESCRIPTION
# Instrument Operation latencies

The change adds instrumentation to the operation runtimes and has
defined configuration which can be used to send realtime metrics to
wavefront.

Micrometer is the industry standard to instrument code and has a very
good integration with spring boot. The change adds all required
gradle dependencies and the configuration placeholders to enable it to
push to wavefront.

Resolves #1